### PR TITLE
updates load_sam_model to support sam 2.1

### DIFF
--- a/node.py
+++ b/node.py
@@ -95,6 +95,7 @@ def load_sam_model(model_name):
         sam_model_list[model_name]["model_url"], sam_model_dir_name
     )
     model_file_name = os.path.basename(sam2_checkpoint_path)
+    model_file_name = model_file_name.replace("2.1", "2_1")
     model_type = model_file_name.split(".")[0]
 
     if GlobalHydra().is_initialized():


### PR DESCRIPTION
Quick fix to handle matching the model  SAM 2.1 model naming convention to the config file naming conventions ("2_1").

Resolves #40 