### PR TITLE
Added offload of the model from memory for GroundingDinoSAM2Segment

### DIFF
--- a/node.py
+++ b/node.py
@@ -263,7 +263,6 @@ def offload_models(sam_model, grounding_dino_model, keep_model_loaded):
         device = comfy.model_management.unet_offload_device()
         sam_model.to(device=device)
         grounding_dino_model.to(device=device)
-        
         comfy.model_management.soft_empty_cache()
 
 class SAM2ModelLoader:


### PR DESCRIPTION
The idea of offload the model came to me when working with Wan Animate on a video card with 6GB of VRAM. I had to reduce the size of the video and image to fit all the models into the video memory.
This is inconvenient, and I wanted to be able to unload unused models from memory. That's how this PR turned out. Here I have set the new `keep_model_loaded` parameter to **GroundingDinoSAM2Segment**. This parameter allows you to leave the model in memory or offload it to the CPU after the node is executed.